### PR TITLE
Unit Test: Custom DateTime formats assume UTC

### DIFF
--- a/OpenPopUnitTests/Mime/Decode/Rfc2822DateTimeTests.cs
+++ b/OpenPopUnitTests/Mime/Decode/Rfc2822DateTimeTests.cs
@@ -387,6 +387,17 @@ namespace OpenPopUnitTests.Mime.Decode
 		}
 
 		[Test]
+		public void TestCustomFormatHandlesNoTimezone()
+		{
+			//If not timezome is supplied, custom formats should assume UTC
+			Rfc2822DateTime.CustomDateTimeFormats = new string[] { "ddd, dd MM yyyy HH:mm:ss" };
+			Assert.AreEqual(new DateTime(2014, 12, 30, 10, 59, 22, DateTimeKind.Utc), Rfc2822DateTime.StringToDate("Tue, 30 12 2014 10:59:22"));
+
+			//Reset the custom formats
+			Rfc2822DateTime.CustomDateTimeFormats = null;
+		}
+
+		[Test]
 		public void TestWrongFormatParses()
 		{
 			// This is a valid date, but in a incorrect format


### PR DESCRIPTION
When no timezone is supplied, any Custom DateTime formats should assume the timezone is UTC (as is the behaviour when not using a custom format).
It already does this, just added a unit test to check it does (I was looking for as bug and wanted to make sure this was behaving as expected).