### PR TITLE
Logging an Error when DateTime could still sget parsed using a custom format

### DIFF
--- a/OpenPop/Mime/Decode/Rfc2822DateTime.cs
+++ b/OpenPop/Mime/Decode/Rfc2822DateTime.cs
@@ -230,16 +230,21 @@ namespace OpenPop.Mime.Decode
 				}
 				catch (FormatException)
 				{
-					DefaultLogger.Log.LogError("The given date appeared to be in a valid format, but could not be converted to a DateTime object: " + dateInput);
+					//Only log as an error if we won't be checking it against any custom formats
+					if (CustomDateTimeFormats == null || CustomDateTimeFormats.Length == 0)
+					{
+						DefaultLogger.Log.LogError("The given date appeared to be in a valid format, but could not be converted to a DateTime object: " + dateInput);
+					}
 				}
 			}
-			else
+			//Only log as an error if we won't be checking it against any custom formats
+			else if (CustomDateTimeFormats == null || CustomDateTimeFormats.Length == 0)
 			{
 				DefaultLogger.Log.LogError("The given date does not appear to be in a valid format: " + dateInput);
 			}
 
 			//If there are some custom formats
-			if (CustomDateTimeFormats != null)
+			if (CustomDateTimeFormats != null && CustomDateTimeFormats.Length > 0)
 			{
 				//If there is a timezone at the end, remove it
 				string strDate = dateInput.Trim();

--- a/OpenPopUnitTests/Mime/Decode/Rfc2822DateTimeTests.cs
+++ b/OpenPopUnitTests/Mime/Decode/Rfc2822DateTimeTests.cs
@@ -398,6 +398,16 @@ namespace OpenPopUnitTests.Mime.Decode
 		}
 
 		[Test]
+		public void TestEmptyCustomFormats()
+		{
+			Rfc2822DateTime.CustomDateTimeFormats = new string[0];
+			Assert.AreEqual(DateTime.MinValue, Rfc2822DateTime.StringToDate("test"));
+
+			//Reset the custom formats
+			Rfc2822DateTime.CustomDateTimeFormats = null;
+		}
+
+		[Test]
 		public void TestWrongFormatParses()
 		{
 			// This is a valid date, but in a incorrect format


### PR DESCRIPTION
When looking through my logs I found errors like:
Error: The given date appeared to be in a valid format, but could not be converted to a DateTime object: Thu, 14 05 2015 06:57:43

Which confused me slightly because I had a custom format which covered it.
Turns out I hadn't updated the error logging after implementing Custom DateTime formats.