### PR TITLE
Proposed fix for bug #21

### DIFF
--- a/OpenPopUnitTests/Mime/Header/HeaderFieldParserTests.cs
+++ b/OpenPopUnitTests/Mime/Header/HeaderFieldParserTests.cs
@@ -768,6 +768,17 @@ namespace OpenPopUnitTests.Mime.Header
 			Assert.AreEqual("text/plain", contentType.MediaType);
 			Assert.AreEqual("utf-8", contentType.CharSet);
 		}
+
+		[Test]
+		public void TestWhitespaceStrippedFromMediaType()
+		{
+			const string contentTypeString =
+				"application/vnd.openxmlformats-officedocument.wordprocessingml.documen \r\n\tt";
+
+			ContentType contentType = HeaderFieldParser.ParseContentType(contentTypeString);
+			Assert.NotNull(contentType);
+			Assert.AreEqual("application/vnd.openxmlformats-officedocument.wordprocessingml.document", contentType.MediaType);
+		}
 		#endregion
 
 		#region Content-Transfer-Encoding tests


### PR DESCRIPTION
Clean up the media type of the Content-Type header before using it, since #21 shows cases where the standard isn't being adhered to by other clients.

This shouldn't effect messages that adhere to the standards, but gives some lenience.
Logs a debug message whenever the value gets modified.