### PR TITLE
Rfc2822DateTime Custom format priority

### DIFF
--- a/OpenPop/Mime/Decode/Rfc2822DateTime.cs
+++ b/OpenPop/Mime/Decode/Rfc2822DateTime.cs
@@ -196,6 +196,44 @@ namespace OpenPop.Mime.Decode
 			if (dateInput == null)
 				throw new ArgumentNullException("dateInput");
 
+			//If there are some custom formats, try and parse the dateInput string with these first
+			if (CustomDateTimeFormats != null && CustomDateTimeFormats.Length > 0)
+			{
+				//If there is a timezone at the end, remove it
+				string strDate = dateInput.Trim();
+				if (strDate.Contains(" ")) //Check contains a space before getting the last part to prevent accessing index -1
+				{
+					string[] parts = strDate.Split(' ');
+					string lastPart = parts[parts.Length - 1];
+
+					// Convert timezones in older formats to [+-]dddd format.
+					lastPart = Regex.Replace(lastPart, REGEX_OLD_TIMEZONE_FORMATS, MatchEvaluator);
+
+					// Find the timezone specification
+					// Example: Fri, 21 Nov 1997 09:55:06 -0600
+					// finds -0600
+					Match timezoneMatch = Regex.Match(lastPart, REGEX_NEW_TIMEZONE_FORMATS);
+					if (timezoneMatch.Success)
+					{
+						//This last part is a timezone, remove it
+						strDate = strDate.Substring(0, strDate.Length - parts[parts.Length - 1].Length).Trim(); //Use the length of the old last part
+						DefaultLogger.Log.LogDebug(String.Format("Stripped timezone from \"{0}\" to produce \"{1}\"", dateInput, strDate));
+					}
+				}
+
+				//Try and parse it as one of the custom formats
+				try
+				{
+					DateTime dateTime = DateTime.ParseExact(strDate, CustomDateTimeFormats, null, DateTimeStyles.None);
+					DefaultLogger.Log.LogDebug(String.Format("Successfully parsed date input \"{0}\" using a custom format. Converted to date: {1}", dateInput, dateTime.ToString()));
+					return dateTime;
+				}
+				catch (FormatException)
+				{
+					DefaultLogger.Log.LogDebug("Failed to parse date input using custom formats: " + dateInput);
+				}
+			}
+
 			// Matches the date and time part of a string
 			// Given string example: Fri, 21 Nov 1997 09:55:06 -0600
 			// Needs to find: 21 Nov 1997 09:55:06
@@ -230,55 +268,12 @@ namespace OpenPop.Mime.Decode
 				}
 				catch (FormatException)
 				{
-					//Only log as an error if we won't be checking it against any custom formats
-					if (CustomDateTimeFormats == null || CustomDateTimeFormats.Length == 0)
-					{
-						DefaultLogger.Log.LogError("The given date appeared to be in a valid format, but could not be converted to a DateTime object: " + dateInput);
-					}
+					DefaultLogger.Log.LogError("The given date appeared to be in a valid format, but could not be converted to a DateTime object: " + dateInput);
 				}
 			}
-			//Only log as an error if we won't be checking it against any custom formats
-			else if (CustomDateTimeFormats == null || CustomDateTimeFormats.Length == 0)
+			else
 			{
 				DefaultLogger.Log.LogError("The given date does not appear to be in a valid format: " + dateInput);
-			}
-
-			//If there are some custom formats
-			if (CustomDateTimeFormats != null && CustomDateTimeFormats.Length > 0)
-			{
-				//If there is a timezone at the end, remove it
-				string strDate = dateInput.Trim();
-				if (strDate.Contains(" ")) //Check contains a space before getting the last part to prevent accessing index -1
-				{
-					string[] parts = strDate.Split(' ');
-					string lastPart = parts[parts.Length - 1];
-
-					// Convert timezones in older formats to [+-]dddd format.
-					lastPart = Regex.Replace(lastPart, REGEX_OLD_TIMEZONE_FORMATS, MatchEvaluator);
-
-					// Find the timezone specification
-					// Example: Fri, 21 Nov 1997 09:55:06 -0600
-					// finds -0600
-					Match timezoneMatch = Regex.Match(lastPart, REGEX_NEW_TIMEZONE_FORMATS);
-					if (timezoneMatch.Success)
-					{
-						//This last part is a timezone, remove it
-						strDate = strDate.Substring(0, strDate.Length - parts[parts.Length - 1].Length).Trim(); //Use the length of the old last part
-						DefaultLogger.Log.LogDebug(String.Format("Stripped timezone from \"{0}\" to produce \"{1}\"", dateInput, strDate));
-					}
-				}
-
-				//Try and parse it as one of the custom formats
-				try
-				{
-					DateTime dateTime = DateTime.ParseExact(strDate, CustomDateTimeFormats, null, DateTimeStyles.None);
-					DefaultLogger.Log.LogDebug(String.Format("Successfully parsed date input \"{0}\" using a custom format. Converted to date: {1}", dateInput, dateTime.ToString()));
-					return dateTime;
-				}
-				catch (FormatException)
-				{
-					DefaultLogger.Log.LogError("Failed to parse date input using custom formats: " + dateInput);
-				}
 			}
 
 			return DateTime.MinValue;

--- a/OpenPop/Mime/Decode/Rfc2822DateTime.cs
+++ b/OpenPop/Mime/Decode/Rfc2822DateTime.cs
@@ -217,7 +217,6 @@ namespace OpenPop.Mime.Decode
 					{
 						//This last part is a timezone, remove it
 						strDate = strDate.Substring(0, strDate.Length - parts[parts.Length - 1].Length).Trim(); //Use the length of the old last part
-						DefaultLogger.Log.LogDebug(String.Format("Stripped timezone from \"{0}\" to produce \"{1}\"", dateInput, strDate));
 					}
 				}
 
@@ -228,10 +227,7 @@ namespace OpenPop.Mime.Decode
 					DefaultLogger.Log.LogDebug(String.Format("Successfully parsed date input \"{0}\" using a custom format. Converted to date: {1}", dateInput, dateTime.ToString()));
 					return dateTime;
 				}
-				catch (FormatException)
-				{
-					DefaultLogger.Log.LogDebug("Failed to parse date input using custom formats: " + dateInput);
-				}
+				catch (FormatException) {  }
 			}
 
 			// Matches the date and time part of a string

--- a/OpenPopUnitTests/Mime/Decode/Rfc2822DateTimeTests.cs
+++ b/OpenPopUnitTests/Mime/Decode/Rfc2822DateTimeTests.cs
@@ -398,6 +398,21 @@ namespace OpenPopUnitTests.Mime.Decode
 		}
 
 		[Test]
+		public void TestCustomFormatTakesPriorityExample()
+		{
+			//If a date matches a supplied custom format, then that should be used over the default
+			//	Here a custom format specifies that a UK date format should be assumed (dd/mm/yyyy), whereas 
+			//	by defualt this date would be parsed in the US date format (mm/dd/yyyy)
+			//Note that if it was parsed in the US format it would then warn that the day was incorrect as debug message,
+			//	but for some cases even the day will be correct
+			Rfc2822DateTime.CustomDateTimeFormats = new string[] { "ddd, dd MM yyyy HH:mm:ss" };
+			Assert.AreEqual(new DateTime(2015, 06, 04, 09, 08, 22, DateTimeKind.Utc), Rfc2822DateTime.StringToDate("Thu, 04 06 2015 09:08:22"));
+
+			//Reset the custom formats
+			Rfc2822DateTime.CustomDateTimeFormats = null;
+		}
+
+		[Test]
 		public void TestEmptyCustomFormats()
 		{
 			Rfc2822DateTime.CustomDateTimeFormats = new string[0];


### PR DESCRIPTION
Try and parse a date string with any custom formats before falling back to the standard parser.

The motivation for doing this is demonstrated with a Unit Test; the string has the date in the format commonly used in the UK (dd/mm/yyyy) whereas this would get parsed by the standard parser as (mm/dd/yyyy). 
By having the date string parsed with custom formats beforehand, the date gets parsed in the intended UK format.