### PR TITLE
Update EncodedWord.cs

### DIFF
--- a/OpenPop/Mime/Decode/EncodedWord.cs
+++ b/OpenPop/Mime/Decode/EncodedWord.cs
@@ -77,54 +77,74 @@ namespace OpenPop.Mime.Decode
 			encodedWords = Regex.Replace(encodedWords, replaceRegex, "${first}${second}");
 			encodedWords = Regex.Replace(encodedWords, replaceRegex, "${first}${second}");
 
-			string decodedWords = encodedWords;
-
 			MatchCollection matches = Regex.Matches(encodedWords, encodedWordRegex);
-			foreach (Match match in matches)
-			{
-				// If this match was not a success, we should not use it
-				if (!match.Success) continue;
+            if (matches.Count > 0)
+            {
+                #region decode words
+                string encoding = null;
+                string charset = null;
 
-				string fullMatchValue = match.Value;
+                // Find encoding and charset
+                foreach (Match match in matches)
+                {
+                    if (match.Success)
+                    {
+                        encoding = match.Groups["Encoding"].Value;
+                        charset = match.Groups["Charset"].Value;
+                        break;
+                    }
+                }
+                if (encoding == null)
+                    throw new ArgumentException("The encoding " + encoding + " was not recognized");
 
-				string encodedText = match.Groups["Content"].Value;
-				string encoding = match.Groups["Encoding"].Value;
-				string charset = match.Groups["Charset"].Value;
+                // Join all ecncoded text
+                StringBuilder matchCache = new StringBuilder();
+                StringBuilder encodedCache = new StringBuilder();
+                foreach (Match match in matches)
+                {
+                    // If this match was not a success, we should not use it
+                    if (!match.Success)
+                        continue;
 
-				// Get the encoding which corrosponds to the character set
-				Encoding charsetEncoding = EncodingFinder.FindEncoding(charset);
+                    matchCache.Append(match.Value);
+                    encodedCache.Append(match.Groups["Content"].Value);
+                }
+                string encodedText = encodedCache.ToString();
 
-				// Store decoded text here when done
-				string decodedText;
+                // Get the encoding which corrosponds to the character set
+                Encoding charsetEncoding = EncodingFinder.FindEncoding(charset);
 
-				// Encoding may also be written in lowercase
-				switch (encoding.ToUpperInvariant())
-				{
-						// RFC:
-						// The "B" encoding is identical to the "BASE64" 
-						// encoding defined by RFC 2045.
-						// http://tools.ietf.org/html/rfc2045#section-6.8
-					case "B":
-						decodedText = Base64.Decode(encodedText, charsetEncoding);
-						break;
+                // Store decoded text here when done
+                string decodedText;
 
-						// RFC:
-						// The "Q" encoding is similar to the "Quoted-Printable" content-
-						// transfer-encoding defined in RFC 2045.
-						// There are more details to this. Please check
-						// http://tools.ietf.org/html/rfc2047#section-4.2
-						// 
-					case "Q":
-						decodedText = QuotedPrintable.DecodeEncodedWord(encodedText, charsetEncoding);
-						break;
+                // Encoding may also be written in lowercase
+                switch (encoding.ToUpperInvariant())
+                {
+                    // RFC:
+                    // The "B" encoding is identical to the "BASE64" 
+                    // encoding defined by RFC 2045.
+                    // http://tools.ietf.org/html/rfc2045#section-6.8
+                    case "B":
+                        decodedText = Base64.Decode(encodedText, charsetEncoding);
+                        break;
 
-					default:
-						throw new ArgumentException("The encoding " + encoding + " was not recognized");
-				}
+                    // RFC:
+                    // The "Q" encoding is similar to the "Quoted-Printable" content-
+                    // transfer-encoding defined in RFC 2045.
+                    // There are more details to this. Please check
+                    // http://tools.ietf.org/html/rfc2047#section-4.2
+                    // 
+                    case "Q":
+                        decodedText = QuotedPrintable.DecodeEncodedWord(encodedText, charsetEncoding);
+                        break;
 
-				// Repalce our encoded value with our decoded value
-				decodedWords = decodedWords.Replace(fullMatchValue, decodedText);
-			}
+                    default:
+                        throw new ArgumentException("The encoding " + encoding + " was not recognized");
+                }
+
+                decodedWords = decodedWords.Replace(matchCache.ToString(), decodedText);
+                #endregion
+            }
 
 			return decodedWords;
 		}


### PR DESCRIPTION
bug occurs when I load Message from ".eml" file, that has been created some other program,
and it has the MailAddress encoded in UTF-8,
for example: 
I got decoded value "Лучшему кл��енту <jane@contoso.com>"
instead of "Лучшему клиенту <jane@contoso.com>"

you can test old version with headers:
X-Sender: =?utf-8?Q?=D0=A3=D0=B2=D0=B0=D0=B6=D0=B0=D0=B5=D0=BC=D1=8B=D0?=
 =?utf-8?Q?=B9_=D0=BF=D0=BE=D1=81=D1=82=D0=B0=D0=B2=D1=89=D0=B8=D0=BA?=
 <ben@contoso.com>
X-Receiver: =?utf-8?Q?=D0=9B=D1=83=D1=87=D1=88=D0=B5=D0=BC=D1=83_=D0=BA?=
 =?utf-8?Q?=D0=BB=D0=B8=D0=B5=D0=BD=D1=82=D1=83?= <jane@contoso.com>
X-Receiver: =?utf-8?Q?=D0=9B=D1=83=D1=87=D1=88=D0=B5=D0=BC=D1=83_=D0=B4?=
 =?utf-8?Q?=D1=80=D1=83=D0=B3=D1=83_=D0=BB=D1=83=D1=87=D1=88=D0=B5=D0?=
 =?utf-8?Q?=B3=D0=BE_=D0=BA=D0=BB=D0=B8=D0=B5=D0=BD=D1=82=D0=B0?=
 <alex@contoso.com>
MIME-Version: 1.0
From: =?utf-8?Q?=D0=A3=D0=B2=D0=B0=D0=B6=D0=B0=D0=B5=D0=BC=D1=8B=D0=B9?=
 =?utf-8?Q?_=D0=BF=D0=BE=D1=81=D1=82=D0=B0=D0=B2=D1=89=D0=B8=D0=BA?=
 <ben@contoso.com>
To: =?utf-8?Q?=D0=9B=D1=83=D1=87=D1=88=D0=B5=D0=BC=D1=83_=D0=BA=D0=BB=D0?=
 =?utf-8?Q?=B8=D0=B5=D0=BD=D1=82=D1=83?= <jane@contoso.com>,
 =?utf-8?Q?=D0=9B=D1=83=D1=87=D1=88=D0=B5=D0=BC=D1=83_=D0=B4=D1=80=D1?=
 =?utf-8?Q?=83=D0=B3=D1=83_=D0=BB=D1=83=D1=87=D1=88=D0=B5=D0=B3=D0=BE?=
 =?utf-8?Q?_=D0=BA=D0=BB=D0=B8=D0=B5=D0=BD=D1=82=D0=B0?= <alex@contoso.com>